### PR TITLE
Fetch provider lists for all versions automatically

### DIFF
--- a/xmpp-providers-docker/docker-compose.yml
+++ b/xmpp-providers-docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: xsf/xmpp-providers
     build: .
     volumes:
-      - /var/www/vhosts/data.xmpp.net/providers/v1:/var/www/public
+      - /var/www/vhosts/data.xmpp.net/providers:/var/www/public
     restart: always
   website:
     build: xmpp-providers-website


### PR DESCRIPTION
This should automatically generate new entries for new API versions:

Examples:
`https://data.xmpp.net/providers/v1/providers-A.json` fetched from `https://invent.kde.org/melvo/xmpp-providers/-/jobs/artifacts/v1/raw/providers-A.json?job=filtered-provider-lists`
`https://data.xmpp.net/providers/v2/providers-A.json` fetched from `https://invent.kde.org/melvo/xmpp-providers/-/jobs/artifacts/v2/raw/providers-A.json?job=filtered-provider-lists`

@cal0pteryx @Echolon  Here is the approach we discussed.