### PR TITLE
Providers API: Fix path for versions of providers.json file

### DIFF
--- a/xmpp-providers-docker/entrypoint.sh
+++ b/xmpp-providers-docker/entrypoint.sh
@@ -20,7 +20,7 @@ while true; do
 
     # Fetch the original providers file.
     echo "## Fetching v${version} files from ${source_root} to ${destination_root}"
-    curl -L -o "${destination_root}/providers-${version}.json" "${source_root}/providers.json?job=providers-file"
+    curl -L -o "${destination_root}/providers.json" "${source_root}/providers.json?job=providers-file"
 
     # Fetch the filtered provider lists.
     for list in A B C D As Bs Cs Ds; do


### PR DESCRIPTION
This fixes URLs for `providers.json` for different API versions.

Current situation is: `https://data.xmpp.net/providers/v1/providers-1.json`
While this would be correct: `https://data.xmpp.net/providers/v1/providers.json`