### PR TITLE
XMPP Providers: Fetch original files and archives

### DIFF
--- a/xmpp-providers-docker/entrypoint.sh
+++ b/xmpp-providers-docker/entrypoint.sh
@@ -8,25 +8,35 @@ version=1
 
 while true; do
     destination_root="${base_dir}/v${version}"
-    source_root="https://invent.kde.org/melvo/xmpp-providers/-/jobs/artifacts/stable/v${version}/raw"
+    source_root="https://invent.kde.org/melvo/xmpp-providers/-/jobs/artifacts/stable/v${version}"
 
     # Check whether there is a file for the desried version.
-    http_code=$(curl -o /dev/null -w "%{http_code}" "${source_root}/providers.json?job=providers-file")
+    http_code=$(curl -o /dev/null -w "%{http_code}" "${source_root}/download/?job=badges")
 
     # Quit the loop as soon as there is no file for the desired version anymore.
     [ "${http_code}" -ne 404 ] || break
 
     mkdir -p ${destination_root}
 
-    # Fetch the original providers file.
-    echo "## Fetching v${version} files from ${source_root} to ${destination_root}"
-    curl -L -o "${destination_root}/providers.json" "${source_root}/providers.json?job=providers-file"
+    # Fetch original files.
+    if [ "${version}" -eq "1" ]; then
+        curl -L -o "${destination_root}/providers.json" "${source_root}/raw/providers.json?job=providers-file"
+    else
+        for filename in "providers.json" "clients.json"; do
+            curl -L -o "${destination_root}/${filename}" "${source_root}/raw/${filename}?job=original-files"
+        done
+    fi
 
     # Fetch the filtered provider lists.
     for list in A B C D As Bs Cs Ds; do
-	    source="${source_root}/providers-${list}.json?job=filtered-provider-lists"
-	    curl -L -o "${destination_root}/providers-${list}.json" "${source}"
+        curl -L -o "${destination_root}/providers-${list}.json" "${source_root}/raw/providers-${list}.json?job=filtered-provider-lists"
     done
+
+    # Fetch filtered provider lists archive.
+    curl -L -o "${destination_root}/filtered-provider-lists.zip" "${source_root}/download/?job=filtered-provider-lists"
+
+    # Fetch badges archive.
+    curl -L -o "${destination_root}/badges.zip" "${source_root}/download/?job=badges"
 
     version=$((${version} + 1))
 done


### PR DESCRIPTION
This adds the following files to the data.xmpp.net XMPP Providers API:

* filtered-provider-lists.zip
* badges.zip
* clients.json

@mwild1 